### PR TITLE
added OCExpandableButtonDelegate to track control's opening/closure

### DIFF
--- a/OCExpandableButton.h
+++ b/OCExpandableButton.h
@@ -16,9 +16,20 @@ typedef enum {
     OCExpandableButtonAlignmentRight
 } OCExpandableButtonAlignment;
 
+@class OCExpandableButton;
+
+// The delegate allows notification of expandable button opening/closure
+@protocol OCExpandableButtonDelegate
+
+- (void)expandableButtonOpened:(OCExpandableButton*)button;
+- (void)expandableButtonClosed:(OCExpandableButton*)button;
+
+@end
+
 @interface OCExpandableButton : UIView
 
 @property (nonatomic, assign) OCExpandableButtonAlignment alignment;
+@property (nonatomic, strong) id<OCExpandableButtonDelegate> delegate;
 
 //initialize with a specific set of subviews
 - (id)initWithFrame:(CGRect)frame subviews:(NSArray *)subviews;

--- a/OCExpandableButton.m
+++ b/OCExpandableButton.m
@@ -9,7 +9,7 @@
 #import "OCExpandableButton.h"
 #import <QuartzCore/QuartzCore.h>
 
-#define kAnimationDuration 0.1f
+#define kAnimationDuration 0.2f
 
 #define kInactiveGradientColors @[(__bridge id)[UIColor colorWithRed:65/255.f green:105/255.f blue:175/255.f alpha: 1].CGColor, (__bridge id)[UIColor colorWithRed:29/255.f green:47/255.f blue:97/255.f alpha: 1].CGColor]
 #define kInactiveStrokeColor [UIColor colorWithRed:20/255.f green:30/255.f blue:52/255.f alpha: 0.5f].CGColor
@@ -52,6 +52,7 @@ static void init(OCExpandableButton *self) {
     self = [super init];
     if (self) {
         init(self);
+		self.delegate = nil;
     }
     return self;
 }
@@ -216,7 +217,6 @@ static void init(OCExpandableButton *self) {
     _active = !_active;
     
     if(_active) {
-        
         [self animateOpen];
     } else {
         [self animateClose];
@@ -277,6 +277,10 @@ static void init(OCExpandableButton *self) {
     [self setBoundsForLayer:_backgroundGradientLayer newBounds:CGRectMake(0, 0, newWidth, _backgroundGradientLayer.bounds.size.height) duration:kAnimationDuration];
     CGPoint position = CGPointMake(_backgroundGradientLayer.position.x + directionModifier*0.5f*(_backgroundGradientLayer.bounds.size.width - self.bounds.size.width), CGRectGetMidY(self.bounds));
     [self setPositionForLayer:_backgroundGradientLayer newPosition:position duration:kAnimationDuration];
+	
+	// notify
+	if (self.delegate != nil)
+		[self.delegate expandableButtonOpened:self];
 }
 
 - (void)animateClose {
@@ -317,6 +321,10 @@ static void init(OCExpandableButton *self) {
         //rotate back to the start
         [self rotateLayer:_arrowLayer byDegrees:90.f duration:kAnimationDuration];
     }
+	
+	// notify
+	if (self.delegate != nil)
+		[self.delegate expandableButtonClosed:self];
 }
 
 - (void)setPositionForLayer:(CALayer *)layer newPosition:(CGPoint)point duration:(NSTimeInterval)duration {

--- a/readme.markdown
+++ b/readme.markdown
@@ -35,6 +35,19 @@ or
 button.alignment = OCExpandableButtonAlignmentRight;
 ```
 
+You can use the delegate property in order to notify of the control's opening/closure.
+
+	@interface MyClass : NSObject <OCExpandableButtonDelegate>
+		...
+	@end
+	
+	@implementation MyClass
+	...
+	- (void)expandableButtonClosed:(OCExpandableButton*)button
+	{ ... }
+	- (void)expandableButtonOpened:(OCExpandableButton*)button
+	{ ... }
+
 TODO:
 
 - Implement inner shadows like they have in Sparrow - Not sure what the right API looks like here.  Maybe just letting user specify images, or maybe using masks and drawing inner shadows manually?


### PR DESCRIPTION
I added a simple delegation protocol in order to track the expandable button's opening/closure.
Useful in my case, to close one control when another is opened (in order to avoid overlap between to expandable buttons with opposite alignment).
